### PR TITLE
Add mix npm.install task to generators and documentation.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@
 /installer/deps
 
 erl_crash.dump
+
+*.ez

--- a/README.md
+++ b/README.md
@@ -46,9 +46,7 @@ To create projects outside of the `installer/` directory, add the latest archive
 To build the documentation from source:
 
 ```bash
-$ cd assets
-$ npm install
-$ cd ..
+$ mix npm.install
 $ MIX_ENV=docs mix docs
 ```
 
@@ -70,8 +68,8 @@ $ mix archive.build
 ### Building phoenix.js
 
 ```bash
+$ mix npm.install
 $ cd assets
-$ npm install
 $ npm run watch
 ```
 

--- a/guides/phoenix_mix_tasks.md
+++ b/guides/phoenix_mix_tasks.md
@@ -36,7 +36,7 @@ This is how we tell Phoenix the framework to generate a new Phoenix application 
 
 Before we begin, we should note that Phoenix uses [Ecto](https://github.com/elixir-lang/ecto) for database access and [webpack](https://webpack.js.org/) for asset management by default. We can pass `--no-ecto` to opt out of Ecto and  `--no-webpack` to opt out of webpack.
 
-> Note: If we do use webpack, we need to install its dependencies before we start our application. `mix phx.new` will ask to do this for us. Otherwise, we can install them with `npm install`. If we don't install them, the app will throw errors and may not serve our assets properly.
+> Note: If we do use webpack, we need to install its dependencies before we start our application. `mix phx.new` will ask to do this for us. Otherwise, we can install them with `mix npm.install` (or `npm install` from the assets folder). If we don't install them, the app will throw errors and may not serve our assets properly. For umbrella apps, `mix npm.install` must be configured in the root project `mix.exs` file.
 
 We need to pass a name for our application to `mix phx.new`. Conventionally, we use all lower-case letters with underscores.
 
@@ -68,7 +68,8 @@ The `mix phx.new` task will also ask us if we want to install our dependencies. 
 
 ```console
 Fetch and install dependencies? [Yn] y
-* cd assets && npm install && node node_modules/webpack/bin/webpack.js --mode development
+* mix npm.install
+* cd assets && node node_modules/webpack/bin/webpack.js --mode development
 * running mix deps.get
 ```
 

--- a/guides/up_and_running.md
+++ b/guides/up_and_running.md
@@ -14,7 +14,7 @@ We can run `mix phx.new` from any directory in order to bootstrap our Phoenix ap
 $ mix phx.new hello
 ```
 
-> A note about [webpack](https://webpack.js.org/) before we begin: Phoenix will use webpack for asset management by default. Webpack's dependencies are installed via the node package manager, not mix. Phoenix will prompt us to install them at the end of the `mix phx.new` task. If we say "no" at that point, and if we don't install those dependencies later with `npm install`, our application will raise errors when we try to start it, and our assets may not load properly. If we don't want to use webpack at all, we can simply pass `--no-webpack` to `mix phx.new`.
+> A note about [webpack](https://webpack.js.org/) before we begin: Phoenix will use webpack for asset management by default. Webpack's dependencies are installed via the node package manager, not mix. Phoenix will prompt us to install them at the end of the `mix phx.new` task. If we say "no" at that point, and if we don't install those dependencies later with `mix npm.install`, our application will raise errors when we try to start it, and our assets may not load properly. If we don't want to use webpack at all, we can simply pass `--no-webpack` to `mix phx.new`.
 
 > A note about [Ecto](https://hexdocs.pm/phoenix/ecto.html): Ecto allows our Phoenix application to communicate with a data store, such as PostgreSQL, MySQL, or MSSQL. If our application will not require this component we can skip this dependency by passing the `--no-ecto` flag to `mix phx.new`. This flag may also be combined with `--no-webpack` to create a skeleton application.
 
@@ -38,7 +38,8 @@ Phoenix generates the directory structure and all the files we will need for our
 Fetch and install dependencies? [Yn] Y
 * running mix deps.get
 * running mix deps.compile
-* running cd assets && npm install && node node_modules/webpack/bin/webpack.js --mode development
+* running mix npm.install
+* running cd assets && node node_modules/webpack/bin/webpack.js --mode development
 
 We are almost there! The following steps are missing:
 
@@ -97,7 +98,8 @@ We are almost there! The following steps are missing:
 
     $ cd hello
     $ mix deps.get
-    $ cd assets && npm install && node node_modules/webpack/bin/webpack.js --mode development
+    $ mix npm.install
+    $ cd assets && node node_modules/webpack/bin/webpack.js --mode development
 
 Then configure your database in config/dev.exs and run:
 

--- a/installer/lib/mix/tasks/phx.new.ex
+++ b/installer/lib/mix/tasks/phx.new.ex
@@ -182,7 +182,7 @@ defmodule Mix.Tasks.Phx.New do
     assets_path = Path.join(project.web_path || project.project_path, "assets")
     webpack_config = Path.join(assets_path, "webpack.config.js")
 
-    maybe_cmd(project, "cd #{relative_app_path(assets_path)} && npm install && node node_modules/webpack/bin/webpack.js --mode development",
+    maybe_cmd(project, "mix npm.install && cd #{relative_app_path(assets_path)} && node node_modules/webpack/bin/webpack.js --mode development",
               File.exists?(webpack_config), install? && System.find_executable("npm"))
   end
 

--- a/installer/templates/phx_single/README.md
+++ b/installer/templates/phx_single/README.md
@@ -4,7 +4,7 @@ To start your Phoenix server:
 
   * Install dependencies with `mix deps.get`<%= if ecto do %>
   * Create and migrate your database with `mix ecto.setup`<% end %><%= if webpack do %>
-  * Install Node.js dependencies with `cd assets && npm install`<% end %>
+  * Install Node.js dependencies with `mix npm.install` (or `cd assets && npm install`)<% end %>
   * Start Phoenix endpoint with `mix phx.server`
 
 Now you can visit [`localhost:4000`](http://localhost:4000) from your browser.

--- a/installer/templates/phx_single/mix.exs
+++ b/installer/templates/phx_single/mix.exs
@@ -60,6 +60,7 @@ defmodule <%= app_module %>.MixProject do
     [
       "ecto.setup": ["ecto.create", "ecto.migrate", "run priv/repo/seeds.exs"],
       "ecto.reset": ["ecto.drop", "ecto.setup"],
+      "npm.install": ["cmd 'npm install --prefix assets'"],
       test: ["ecto.create --quiet", "ecto.migrate", "test"]
     ]
   end<% end %>

--- a/installer/templates/phx_umbrella/apps/app_name_web/README.md
+++ b/installer/templates/phx_umbrella/apps/app_name_web/README.md
@@ -4,7 +4,7 @@ To start your Phoenix server:
 
   * Install dependencies with `mix deps.get`
   * Create and migrate your database with `mix ecto.setup`
-  * Install Node.js dependencies with `cd assets && npm install`
+  * Install Node.js dependencies with `mix npm.install` (or `cd assets && npm install`)
   * Start Phoenix endpoint with `mix phx.server`
 
 Now you can visit [`localhost:4000`](http://localhost:4000) from your browser.

--- a/installer/templates/phx_umbrella/mix.exs
+++ b/installer/templates/phx_umbrella/mix.exs
@@ -23,6 +23,9 @@ defmodule <%= root_app_module %>.MixProject do
   # Dependencies listed here are available only for this project
   # and cannot be accessed from applications inside the apps folder
   defp deps do
-    []
+    [
+      # "npm.install": ["cmd 'npm install --prefix apps/my_app/assets'",
+      #                 "cmd 'npm install --prefix apps/my_other_app/assets'"]
+    ]
   end
 end

--- a/lib/phoenix/endpoint/watcher.ex
+++ b/lib/phoenix/endpoint/watcher.ex
@@ -39,13 +39,13 @@ defmodule Phoenix.Endpoint.Watcher do
       !System.find_executable("node") ->
         Logger.error "Could not start watcher because \"node\" is not available. Your Phoenix " <>
                      "application is still running, however assets won't be compiled. " <>
-                     "You may fix this by installing \"node\" and then running \"cd assets && npm install\"."
+                     "You may fix this by installing \"node\" and then running \"mix npm.install\" (or \"cd assets && npm install\")."
         exit(:shutdown)
 
       not File.exists?(script_path) ->
         Logger.error "Could not start node watcher because script #{inspect script_path} does not " <>
                      "exist. Your Phoenix application is still running, however assets " <>
-                     "won't be compiled. You may fix this by running \"cd assets && npm install\"."
+                     "won't be compiled. You may fix this by running \"mix npm.install\" (or \"cd assets && npm install\")."
         exit(:shutdown)
 
       true -> :ok


### PR DESCRIPTION
mix npm.install calls npm install from the assets directory via the
--prefix arg.
Umbrella version commented out with example of running in
multiple child apps.